### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/utils/JarUtils.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/utils/JarUtils.java
@@ -50,6 +50,9 @@ public class JarUtils {
     private static final int[] MESSAGE_DIGEST_OID =
         new int[] {1, 2, 840, 113549, 1, 9, 4};
 
+    private JarUtils() {
+    }
+
     /**
      * @see #verifySignature(InputStream, InputStream, boolean)
      */

--- a/app/src/main/java/android/framework/util/jar/JarFileHelper.java
+++ b/app/src/main/java/android/framework/util/jar/JarFileHelper.java
@@ -11,6 +11,9 @@ import java.util.Enumeration;
 import java.util.zip.ZipFile;
 
 public class JarFileHelper {
+    private JarFileHelper() {
+    }
+
         public static Certificate[] getSignedJarCerts(String jarName, boolean chainCheck) throws Exception {
             File file = new File(jarName);
             Certificate[] foundCerts = null;

--- a/app/src/main/java/fuzion24/device/vulnerability/util/GenericUtils.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/util/GenericUtils.java
@@ -7,6 +7,9 @@ import com.nowsecure.android.vts.R;
 
 public class GenericUtils {
 
+    private GenericUtils() {
+    }
+
     public static int getActionBarHeight(Context context) {
         final TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(new int[]{R.attr.actionBarSize});
         int toolbarHeight = (int) styledAttributes.getDimension(0, 0);

--- a/app/src/main/java/fuzion24/device/vulnerability/util/SharedPreferencesUtils.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/util/SharedPreferencesUtils.java
@@ -18,6 +18,9 @@ public class SharedPreferencesUtils {
 
     private static final String PREFS_NAME = "com.nowsecure.android.vts.PREFERENCE_FILE_KEY";
 
+    private SharedPreferencesUtils() {
+    }
+
     private static SharedPreferences getPreferences(Context context) {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityOrganizer.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityOrganizer.java
@@ -33,6 +33,9 @@ public class VulnerabilityOrganizer {
 
     private static final String TAG = "VulnerabilityOrganizer";
 
+    private VulnerabilityOrganizer() {
+    }
+
     //TODO: Maybe add dates to each of these and sort chronologically
     public static List<VulnerabilityTest> getTests(Context ctx){
         List<VulnerabilityTest> allTests = new ArrayList<>();

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityResultSerialzier.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityResultSerialzier.java
@@ -16,6 +16,9 @@ import fuzion24.device.vulnerability.util.DeviceInfo;
  */
 public class VulnerabilityResultSerialzier {
 
+    private VulnerabilityResultSerialzier() {
+    }
+
     public static JSONObject serializeResultsToJson(List<VulnerabilityTestResult> results, DeviceInfo devInfo) throws JSONException {
         // not sure if this is too intense to do on the main thread...
         JSONArray testResults = new JSONArray();

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/helper/DeviceUpdateChecker.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/helper/DeviceUpdateChecker.java
@@ -16,6 +16,9 @@ import fuzion24.device.vulnerability.util.SharedPreferencesUtils;
  * Created by fuzion24 on 12/4/15.
  */
 public class DeviceUpdateChecker {
+    private DeviceUpdateChecker() {
+    }
+
     public static boolean wasDeviceUpdated(Context ctx){
 
         /*

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/helper/SystemUtils.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/helper/SystemUtils.java
@@ -27,6 +27,9 @@ import java.lang.reflect.Method;
  * Utilities for accessing /proc filesystem information.
  */
 public class SystemUtils {
+    private SystemUtils() {
+    }
+
     public static int ProcfindPidFor(String executable) throws IOException {
         File f = new File("/proc");
         for (File d : f.listFiles()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.