### PR TITLE
Resources should be closed

### DIFF
--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
@@ -86,8 +86,7 @@ public class ZipBug8219321 implements VulnerabilityTest {
         outstream.close();
 
         // see if we can still handle it
-        try {
-            ZipFile bad = new ZipFile(badZip);
+        try (ZipFile bad = new ZipFile(badZip)) {
             return true;
         } catch (ZipException expected) {
             if(expected.getMessage().contains("Duplicate entry name"))

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
@@ -99,7 +99,7 @@ public class ZipBug9695860 implements VulnerabilityTest {
             if(entry.getName().equals(fileName2))
                 return true;
         }
-
+        bad.close();
         return false;
 
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
@@ -85,7 +85,7 @@ public class ZipBug9950697 implements VulnerabilityTest {
         DataInputStream dis = new DataInputStream(bad.getInputStream(ze));
         byte [] buf = new byte[(int)ze.getSize()];
         dis.readFully(buf);
-
+        bad.close();
         return new String(buf).startsWith("AAAAAAAAAAAAAAA");
     }
 }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/CVE20153860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/CVE20153860.java
@@ -133,6 +133,10 @@ public class CVE20153860 implements VulnerabilityTest {
         if (byteArrayOutputStream == null) {
             throw new IOException("fileToUnzipPath not found in archive.");
         }
-        return byteArrayOutputStream.toByteArray();
+        byte[] byteArray = byteArrayOutputStream.toByteArray();
+        zipInputStream.close();
+        byteArrayOutputStream.close();
+
+        return byteArray;
     }
 }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
@@ -60,20 +60,20 @@ public class SamsungCREDzip implements VulnerabilityTest {
         if(!thisHasSDCardPermission(context))
             throw new Exception("No SDCard permission assigned to app to perform Samsung cred.zip remote code execution test");
 
+        InputStream in = null;
+        OutputStream out = null;
         try{
             AssetManager assetFiles = context.getAssets();
             File outFile = new File(DESTINATION, FILENAME);
-            InputStream in = assetFiles.open(ASSETNAME);
-            OutputStream out = new FileOutputStream(outFile);
+            in = assetFiles.open(ASSETNAME);
+            out = new FileOutputStream(outFile);
             
             byte[] buffer = new byte[BUFFER_SIZE];
             int read;
             while((read = in.read(buffer)) != -1){
                 out.write(buffer, 0, read);
             }
-            in.close();
-            out.close();
-            
+
             Thread.sleep(3000);
          
             outFile = null;
@@ -86,6 +86,11 @@ public class SamsungCREDzip implements VulnerabilityTest {
             }
         }catch(IOException e){
             throw new Exception("Error when extracting the asset file: " + e);
+        }finally{
+            if (in != null)
+                in.close();
+            if (out != null)
+                out.close();
         }
         
         return isVuln;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.