### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertFactoryImpl.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertFactoryImpl.java
@@ -150,7 +150,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
                     // prepare for data format determination
                     inStream.mark(CERT_CACHE_SEED_LENGTH);
                 } else { // unsupported data
-                    if (result.size() == 0) {
+                    if (result.isEmpty()) {
                         throw new CertificateException("Unsupported encoding");
                     } else {
                         // it can be trailing user data,
@@ -171,7 +171,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
                 }
                 // check if it is a TBSCertificate structure
                 if (second_asn1_tag != ASN1Constants.TAG_C_SEQUENCE) {
-                    if (result.size() == 0) {
+                    if (result.isEmpty()) {
                         // there were not read X.509 Certificates, so
                         // break the cycle and check
                         // whether it is PKCS7 structure
@@ -191,7 +191,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
                 // mark for the next iteration
                 inStream.mark(1);
             }
-            if (result.size() != 0) {
+            if (!result.isEmpty()) {
                 // some Certificates have been read
                 return result;
             } else if (ch == -1) {
@@ -290,7 +290,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
                     // prepare for data format determination
                     inStream.mark(CRL_CACHE_SEED_LENGTH);
                 } else { // unsupported data
-                    if (result.size() == 0) {
+                    if (result.isEmpty()) {
                         throw new CRLException("Unsupported encoding");
                     } else {
                         // it can be trailing user data,
@@ -311,7 +311,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
                 }
                 // check if it is a TBSCertList structure
                 if (second_asn1_tag != ASN1Constants.TAG_C_SEQUENCE) {
-                    if (result.size() == 0) {
+                    if (result.isEmpty()) {
                         // there were not read X.509 CRLs, so
                         // break the cycle and check
                         // whether it is PKCS7 structure
@@ -330,7 +330,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
                 }
                 inStream.mark(1);
             }
-            if (result.size() != 0) {
+            if (!result.isEmpty()) {
                 // the stream was read out
                 return result;
             } else if (ch == -1) {

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/CRLDistributionPoints.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/CRLDistributionPoints.java
@@ -69,7 +69,7 @@ public final class CRLDistributionPoints extends ExtensionValue {
     private byte[] encoding;
 
     private CRLDistributionPoints(List<DistributionPoint> distributionPoints, byte[] encoding) {
-        if ((distributionPoints == null) || (distributionPoints.size() == 0)) {
+        if ((distributionPoints == null) || (distributionPoints.isEmpty())) {
             throw new IllegalArgumentException("distributionPoints are empty");
         }
         this.distributionPoints = distributionPoints;

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/GeneralNames.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/GeneralNames.java
@@ -69,7 +69,7 @@ public final class GeneralNames {
      * Returns the list of values.
      */
     public List<GeneralName> getNames() {
-        if ((generalNames == null) || (generalNames.size() == 0)) {
+        if ((generalNames == null) || (generalNames.isEmpty())) {
             return null;
         }
         return new ArrayList<GeneralName>(generalNames);

--- a/app/src/main/java/android/framework/util/jar/JarFile.java
+++ b/app/src/main/java/android/framework/util/jar/JarFile.java
@@ -456,7 +456,7 @@ public class JarFile extends ZipFile {
                 list.add(ze);
             }
         }
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             return null;
         }
         ZipEntry[] result = new ZipEntry[list.size()];

--- a/app/src/main/java/android/framework/util/jar/JarVerifier.java
+++ b/app/src/main/java/android/framework/util/jar/JarVerifier.java
@@ -178,7 +178,7 @@ class JarVerifier {
         // If no manifest is present by the time an entry is found,
         // verification cannot occur. If no signature files have
         // been found, do not verify.
-        if (man == null || signatures.size() == 0) {
+        if (man == null || signatures.isEmpty()) {
             return null;
         }
 
@@ -390,7 +390,7 @@ class JarVerifier {
      *         otherwise.
      */
     boolean isSignedJar() {
-        return certificates.size() > 0;
+        return !certificates.isEmpty();
     }
 
     private boolean verify(Attributes attributes, String entry, byte[] data,

--- a/app/src/main/java/org/apache/commons/compress/archivers/zip/ModdedZipArchiveOutputStream.java
+++ b/app/src/main/java/org/apache/commons/compress/archivers/zip/ModdedZipArchiveOutputStream.java
@@ -407,7 +407,7 @@ public class ModdedZipArchiveOutputStream extends ArchiveOutputStream {
 
         final byte PADDING_BYTE = 0x00;
 
-        if(hiddenEntries.size() > 0){
+        if(!hiddenEntries.isEmpty()){
             ByteArrayOutputStream centralHeaderBytes = new ByteArrayOutputStream();
 
             for (ZipArchiveEntry ze : hiddenEntries)
@@ -471,7 +471,7 @@ public class ModdedZipArchiveOutputStream extends ArchiveOutputStream {
 
         cdLength = written - cdOffset;
         writeZip64CentralDirectory();
-        writeCentralDirectoryEnd(Math.max(hiddenEntries.size(),normalEntries.size()) + (hiddenEntries.size() > 0 ? 1 : 0));
+        writeCentralDirectoryEnd(Math.max(hiddenEntries.size(),normalEntries.size()) + (!hiddenEntries.isEmpty() ? 1 : 0));
         offsets.clear();
         entries.clear();
         def.end();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.