### PR TITLE
The operator ("<>") should be used.

### DIFF
--- a/app/src/main/java/android/framework/libcore/io/Streams.java
+++ b/app/src/main/java/android/framework/libcore/io/Streams.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 public final class Streams {
-    private static AtomicReference<byte[]> skipBuffer = new AtomicReference<byte[]>();
+    private static AtomicReference<byte[]> skipBuffer = new AtomicReference<>();
 
     private Streams() {}
 

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/asn1/ASN1Choice.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/asn1/ASN1Choice.java
@@ -233,7 +233,7 @@ public abstract class ASN1Choice extends ASN1Type {
         }
 
         // create map of all identifiers
-        TreeMap<BigInteger, BigInteger> map = new TreeMap<BigInteger, BigInteger>();
+        TreeMap<BigInteger, BigInteger> map = new TreeMap<>();
         for (int index = 0; index < type.length; index++) {
             ASN1Type t = type[index];
 

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/asn1/BerInputStream.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/asn1/BerInputStream.java
@@ -620,7 +620,7 @@ public class BerInputStream {
         } else {
             int seqTagOffset = tagOffset; //store tag offset
 
-            ArrayList<Object> values = new ArrayList<Object>();
+            ArrayList<Object> values = new ArrayList<>();
             while (endOffset > offset) {
                 next();
                 values.add(type.decode(this));

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertFactoryImpl.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertFactoryImpl.java
@@ -123,7 +123,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
         if (inStream == null) {
             throw new CertificateException("inStream == null");
         }
-        ArrayList<Certificate> result = new ArrayList<Certificate>();
+        ArrayList<Certificate> result = new ArrayList<>();
         try {
             if (!inStream.markSupported()) {
                 // create the mark supporting wrapper
@@ -264,7 +264,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
         if (inStream == null) {
             throw new CRLException("inStream == null");
         }
-        ArrayList<CRL> result = new ArrayList<CRL>();
+        ArrayList<CRL> result = new ArrayList<>();
         try {
             if (!inStream.markSupported()) {
                 inStream = new RestoringInputStream(inStream);

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertPathImpl.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertPathImpl.java
@@ -174,9 +174,9 @@ public class X509CertPathImpl extends CertPath {
                 List<Certificate> certs = sd.getCertificates();
                 if (certs == null) {
                     // empty chain of certificates
-                    certs = new ArrayList<Certificate>();
+                    certs = new ArrayList<>();
                 }
-                List<X509CertImpl> result = new ArrayList<X509CertImpl>();
+                List<X509CertImpl> result = new ArrayList<>();
                 for (Certificate cert : certs) {
                     result.add(new X509CertImpl(cert));
                 }
@@ -226,9 +226,9 @@ public class X509CertPathImpl extends CertPath {
                 }
                 List<Certificate> certs = sd.getCertificates();
                 if (certs == null) {
-                    certs = new ArrayList<Certificate>();
+                    certs = new ArrayList<>();
                 }
-                List<X509CertImpl> result = new ArrayList<X509CertImpl>();
+                List<X509CertImpl> result = new ArrayList<>();
                 for (Certificate cert : certs) {
                     result.add(new X509CertImpl(cert));
                 }

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/utils/AlgNameMapper.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/utils/AlgNameMapper.java
@@ -75,11 +75,11 @@ public class AlgNameMapper {
         {"2.23.42.9.11.4.1",        "ECDSA"},
     };
     // Maps alg name to OID
-    private static final Map<String, String> alg2OidMap = new HashMap<String, String>();
+    private static final Map<String, String> alg2OidMap = new HashMap<>();
     // Maps OID to alg name
-    private static final Map<String, String> oid2AlgMap = new HashMap<String, String>();
+    private static final Map<String, String> oid2AlgMap = new HashMap<>();
     // Maps aliases to alg names
-    private static final Map<String, String> algAliasesMap = new HashMap<String, String>();
+    private static final Map<String, String> algAliasesMap = new HashMap<>();
 
     static {
         for (String[] element : knownAlgMappings) {

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x501/AttributeTypeAndValue.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x501/AttributeTypeAndValue.java
@@ -45,19 +45,19 @@ public final class AttributeTypeAndValue {
 
     /** known attribute types for RFC1779 (see Table 1) */
     private static final HashMap<String, ObjectIdentifier> RFC1779_NAMES
-            = new HashMap<String, ObjectIdentifier>(10);
+            = new HashMap<>(10);
 
     /** known keywords attribute */
     private static final HashMap<String, ObjectIdentifier> KNOWN_NAMES
-            = new HashMap<String, ObjectIdentifier>(30);
+            = new HashMap<>(30);
 
     /** known attribute types for RFC2253 (see 2.3.  Converting AttributeTypeAndValue) */
     private static final HashMap<String, ObjectIdentifier> RFC2253_NAMES
-            = new HashMap<String, ObjectIdentifier>(10);
+            = new HashMap<>(10);
 
     /** known attribute types for RFC2459 (see API spec.) */
     private static final HashMap<String, ObjectIdentifier> RFC2459_NAMES
-            = new HashMap<String, ObjectIdentifier>(10);
+            = new HashMap<>(10);
 
     /** Country code attribute (name from RFC 1779) */
     private static final ObjectIdentifier C

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x501/Name.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x501/Name.java
@@ -173,7 +173,7 @@ public final class Name {
             List<AttributeTypeAndValue> atavList = rdn.get(i);
 
             if (X500Principal.CANONICAL == format) {
-                atavList = new ArrayList<AttributeTypeAndValue>(atavList);
+                atavList = new ArrayList<>(atavList);
                 Collections.sort(atavList, new AttributeTypeAndValueComparator());
             }
 

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/CertificatePolicies.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/CertificatePolicies.java
@@ -68,13 +68,13 @@ public final class CertificatePolicies extends ExtensionValue {
      * Returns the values of policyInformation field of the structure.
      */
     public List<PolicyInformation> getPolicyInformations() {
-        return new ArrayList<PolicyInformation>(policyInformations);
+        return new ArrayList<>(policyInformations);
     }
 
     public CertificatePolicies addPolicyInformation(PolicyInformation policyInformation) {
         encoding = null;
         if (policyInformations == null) {
-            policyInformations = new ArrayList<PolicyInformation>();
+            policyInformations = new ArrayList<>();
         }
         policyInformations.add(policyInformation);
         return this;

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/DNParser.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/DNParser.java
@@ -384,14 +384,14 @@ public final class DNParser {
      *         each RDN is represented as a list of AttributeTypeAndValue objects
      */
     public List<List<AttributeTypeAndValue>> parse() throws IOException {
-        List<List<AttributeTypeAndValue>> list = new ArrayList<List<AttributeTypeAndValue>>();
+        List<List<AttributeTypeAndValue>> list = new ArrayList<>();
 
         String attType = nextAT();
         if (attType == null) {
             return list; //empty list of RDNs
         }
 
-        List<AttributeTypeAndValue> atav = new ArrayList<AttributeTypeAndValue>();
+        List<AttributeTypeAndValue> atav = new ArrayList<>();
         while (true) {
             if (pos == chars.length) {
                 //empty Attribute Value
@@ -425,7 +425,7 @@ public final class DNParser {
 
             if (chars[pos] == ',' || chars[pos] == ';') {
                 list.add(0, atav);
-                atav = new ArrayList<AttributeTypeAndValue>();
+                atav = new ArrayList<>();
             } else if (chars[pos] != '+') {
                 throw new IOException("Invalid distinguished name string");
             }

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/Extensions.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/Extensions.java
@@ -116,8 +116,8 @@ public final class Extensions {
             return;
         }
         int size = extensions.size();
-        critical = new HashSet<String>(size);
-        noncritical = new HashSet<String>(size);
+        critical = new HashSet<>(size);
+        noncritical = new HashSet<>(size);
         for (Extension extension : extensions) {
             String oid = extension.getExtnID();
             if (extension.getCritical()) {
@@ -139,7 +139,7 @@ public final class Extensions {
             return null;
         }
         if (oidMap == null) {
-            oidMap = new HashMap<String, Extension>();
+            oidMap = new HashMap<>();
             for (Extension extension : extensions) {
                 oidMap.put(extension.getExtnID(), extension);
             }

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/GeneralName.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/GeneralName.java
@@ -444,7 +444,7 @@ public final class GeneralName {
      * containing the ASN.1 DER encoded form of the name.
      */
     public List<Object> getAsList() {
-        ArrayList<Object> result = new ArrayList<Object>();
+        ArrayList<Object> result = new ArrayList<>();
         result.add(tag);
         switch (tag) {
             case OTHER_NAME:

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/GeneralNames.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/GeneralNames.java
@@ -53,7 +53,7 @@ public final class GeneralNames {
     private byte[] encoding;
 
     public GeneralNames() {
-        generalNames = new ArrayList<GeneralName>();
+        generalNames = new ArrayList<>();
     }
 
     public GeneralNames(List<GeneralName> generalNames) {
@@ -72,14 +72,14 @@ public final class GeneralNames {
         if ((generalNames == null) || (generalNames.size() == 0)) {
             return null;
         }
-        return new ArrayList<GeneralName>(generalNames);
+        return new ArrayList<>(generalNames);
     }
 
     /**
      * Returns the collection of pairs: (Integer (tag), Object (name value))*
      */
     public Collection<List<?>> getPairsList() {
-        Collection<List<?>> result = new ArrayList<List<?>>();
+        Collection<List<?>> result = new ArrayList<>();
         if (generalNames == null) {
             return result;
         }
@@ -92,7 +92,7 @@ public final class GeneralNames {
     public void addName(GeneralName name) {
         encoding = null;
         if (generalNames == null) {
-            generalNames = new ArrayList<GeneralName>();
+            generalNames = new ArrayList<>();
         }
         generalNames.add(name);
     }

--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/NameConstraints.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/x509/NameConstraints.java
@@ -113,7 +113,7 @@ public final class NameConstraints extends ExtensionValue {
                 GeneralName name = generalSubtree.getBase();
                 int tag = name.getTag();
                 if (permitted_names[tag] == null) {
-                    permitted_names[tag] = new ArrayList<GeneralName>();
+                    permitted_names[tag] = new ArrayList<>();
                 }
                 permitted_names[tag].add(name);
             }
@@ -125,7 +125,7 @@ public final class NameConstraints extends ExtensionValue {
                 GeneralName name = generalSubtree.getBase();
                 int tag = name.getTag();
                 if (excluded_names[tag] == null) {
-                    excluded_names[tag] = new ArrayList<GeneralName>();
+                    excluded_names[tag] = new ArrayList<>();
                 }
                 excluded_names[tag].add(name);
             }

--- a/app/src/main/java/android/framework/util/jar/Attributes.java
+++ b/app/src/main/java/android/framework/util/jar/Attributes.java
@@ -181,7 +181,7 @@ public class Attributes implements Cloneable, Map<Object, Object> {
      * Constructs an {@code Attributes} instance.
      */
     public Attributes() {
-        map = new HashMap<Object, Object>();
+        map = new HashMap<>();
     }
 
     /**
@@ -204,7 +204,7 @@ public class Attributes implements Cloneable, Map<Object, Object> {
      *            Initial size of this {@code Attributes} instance.
      */
     public Attributes(int size) {
-        map = new HashMap<Object, Object>(size);
+        map = new HashMap<>(size);
     }
 
     /**

--- a/app/src/main/java/android/framework/util/jar/JarEntry.java
+++ b/app/src/main/java/android/framework/util/jar/JarEntry.java
@@ -154,8 +154,8 @@ public class JarEntry extends ZipEntry {
         }
 
         X500Principal prevIssuer = null;
-        ArrayList<Certificate> list = new ArrayList<Certificate>(certs.length);
-        ArrayList<CodeSigner> asigners = new ArrayList<CodeSigner>();
+        ArrayList<Certificate> list = new ArrayList<>(certs.length);
+        ArrayList<CodeSigner> asigners = new ArrayList<>();
 
         for (Certificate element : certs) {
             if (!(element instanceof X509Certificate)) {

--- a/app/src/main/java/android/framework/util/jar/JarFile.java
+++ b/app/src/main/java/android/framework/util/jar/JarFile.java
@@ -447,7 +447,7 @@ public class JarFile extends ZipFile {
      * @return the list of ZipEntry's or {@code null} if there are none.
      */
     private ZipEntry[] getMetaEntriesImpl() {
-        List<ZipEntry> list = new ArrayList<ZipEntry>(8);
+        List<ZipEntry> list = new ArrayList<>(8);
         Enumeration<? extends ZipEntry> allEntries = entries();
         while (allEntries.hasMoreElements()) {
             ZipEntry ze = allEntries.nextElement();

--- a/app/src/main/java/android/framework/util/jar/JarFileHelper.java
+++ b/app/src/main/java/android/framework/util/jar/JarFileHelper.java
@@ -40,13 +40,13 @@ public class JarFileHelper {
 
 
     public static boolean isExploitingBug13678484(String apkName) throws Exception {
-        ArrayList<String> validatedCertChain = new ArrayList<String>();
+        ArrayList<String> validatedCertChain = new ArrayList<>();
 
         Certificate[] certs = JarFileHelper.getSignedJarCerts(apkName, true);
         for(Certificate c: certs)
             validatedCertChain.add(((X509Certificate)c).getSubjectDN().toString());
 
-        ArrayList<String> unvalidatedCertChain = new ArrayList<String>();
+        ArrayList<String> unvalidatedCertChain = new ArrayList<>();
 
         Certificate[] certsfalse = JarFileHelper.getSignedJarCerts(apkName, false);
         for(Certificate c: certsfalse)

--- a/app/src/main/java/android/framework/util/jar/JarVerifier.java
+++ b/app/src/main/java/android/framework/util/jar/JarVerifier.java
@@ -59,15 +59,15 @@ class JarVerifier {
 
     private Manifest man;
 
-    private HashMap<String, byte[]> metaEntries = new HashMap<String, byte[]>(5);
+    private HashMap<String, byte[]> metaEntries = new HashMap<>(5);
 
-    private final Hashtable<String, HashMap<String, Attributes>> signatures = new Hashtable<String, HashMap<String, Attributes>>(
+    private final Hashtable<String, HashMap<String, Attributes>> signatures = new Hashtable<>(
             5);
 
-    private final Hashtable<String, Certificate[]> certificates = new Hashtable<String, Certificate[]>(
+    private final Hashtable<String, Certificate[]> certificates = new Hashtable<>(
             5);
 
-    private final Hashtable<String, Certificate[]> verifiedEntries = new Hashtable<String, Certificate[]>();
+    private final Hashtable<String, Certificate[]> verifiedEntries = new Hashtable<>();
 
     int mainAttributesEnd;
 
@@ -188,7 +188,7 @@ class JarVerifier {
             return null;
         }
 
-        ArrayList<Certificate> certs = new ArrayList<Certificate>();
+        ArrayList<Certificate> certs = new ArrayList<>();
         Iterator<Map.Entry<String, HashMap<String, Attributes>>> it = signatures.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<String, HashMap<String, Attributes>> entry = it.next();
@@ -324,7 +324,7 @@ class JarVerifier {
 
         // Verify manifest hash in .sf file
         Attributes attributes = new Attributes();
-        HashMap<String, Attributes> entries = new HashMap<String, Attributes>();
+        HashMap<String, Attributes> entries = new HashMap<>();
         try {
             InitManifest im = new InitManifest(sfBytes, attributes, Attributes.Name.SIGNATURE_VERSION);
             im.initEntries(entries, null);
@@ -472,7 +472,7 @@ class JarVerifier {
      */
     public static Vector<Certificate> getSignerCertificates(
             String signatureFileName, Map<String, Certificate[]> certificates) {
-        Vector<Certificate> result = new Vector<Certificate>();
+        Vector<Certificate> result = new Vector<>();
         Certificate[] certChain = certificates.get(signatureFileName);
         if (certChain != null) {
             for (Certificate element : certChain) {

--- a/app/src/main/java/android/framework/util/jar/Manifest.java
+++ b/app/src/main/java/android/framework/util/jar/Manifest.java
@@ -62,7 +62,7 @@ public class Manifest implements Cloneable {
 
     private Attributes mainAttributes = new Attributes();
 
-    private HashMap<String, Attributes> entries = new HashMap<String, Attributes>();
+    private HashMap<String, Attributes> entries = new HashMap<>();
 
     static class Chunk {
         int start;
@@ -117,7 +117,7 @@ public class Manifest implements Cloneable {
 
     Manifest(InputStream is, boolean readChunks) throws IOException {
         if (readChunks) {
-            chunks = new HashMap<String, Chunk>();
+            chunks = new HashMap<>();
         }
         read(is);
     }

--- a/app/src/main/java/fr/xgouchet/axml/CompressedXmlDomListener.java
+++ b/app/src/main/java/fr/xgouchet/axml/CompressedXmlDomListener.java
@@ -39,7 +39,7 @@ public class CompressedXmlDomListener implements CompressedXmlParserListener {
 	 */
 	public CompressedXmlDomListener() throws ParserConfigurationException {
 		mBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		mStack = new Stack<Node>();
+		mStack = new Stack<>();
 	}
 
 	public void startDocument() {

--- a/app/src/main/java/fr/xgouchet/axml/CompressedXmlParser.java
+++ b/app/src/main/java/fr/xgouchet/axml/CompressedXmlParser.java
@@ -65,7 +65,7 @@ public class CompressedXmlParser {
 			"pt", "in", "mm" };
 
 	public CompressedXmlParser() {
-		mNamespaces = new HashMap<String, String>();
+		mNamespaces = new HashMap<>();
 	}
 
 	/**

--- a/app/src/main/java/fuzion24/application/vulnerability/detector/ApplicationVulnerabilityTester.java
+++ b/app/src/main/java/fuzion24/application/vulnerability/detector/ApplicationVulnerabilityTester.java
@@ -46,8 +46,8 @@ public class ApplicationVulnerabilityTester extends AsyncTask<Void,Integer,List<
             PackageManager pm = mCtx.getPackageManager();
             List<ApplicationInfo> apps = pm.getInstalledApplications(PackageManager.GET_SHARED_LIBRARY_FILES | PackageManager.GET_META_DATA);
 
-            List<ApplicationVulnTestResult> applicationVulnerabilityTestResults = new ArrayList<ApplicationVulnTestResult>();
-            List<Pair<ApplicationInfo,Exception>> untestedApps = new ArrayList<Pair<ApplicationInfo,Exception>>();
+            List<ApplicationVulnTestResult> applicationVulnerabilityTestResults = new ArrayList<>();
+            List<Pair<ApplicationInfo,Exception>> untestedApps = new ArrayList<>();
 
             for(int i = 0; i < apps.size(); i++) {
 

--- a/app/src/main/java/fuzion24/device/vulnerability/broadcastreceiver/ScanRunnerBroadcastReceiver.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/broadcastreceiver/ScanRunnerBroadcastReceiver.java
@@ -61,7 +61,7 @@ public class ScanRunnerBroadcastReceiver extends BroadcastReceiver {
             @Override
             protected Void doInBackground(Void... params) {
                 List<VulnerabilityTest> tests = VulnerabilityOrganizer.getTests(context);
-                List<VulnerabilityTestResult> results = new ArrayList<VulnerabilityTestResult>();
+                List<VulnerabilityTestResult> results = new ArrayList<>();
                 for(VulnerabilityTest vt : tests){
                     Log.d(TAG, "Running: " + vt.getCVEorID());
                     boolean vulnerable = false;

--- a/app/src/main/java/fuzion24/device/vulnerability/test/VulnerabilityDescriptor.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/test/VulnerabilityDescriptor.java
@@ -55,7 +55,7 @@ public class VulnerabilityDescriptor {
 
     private static List<String> extractStringArray(JSONObject obj, String arrayName) throws Exception {
         JSONArray jsonStringArray = obj.getJSONArray(arrayName);
-        List<String> items = new ArrayList<String>();
+        List<String> items = new ArrayList<>();
         for (int i = 0; i < jsonStringArray.length(); i++) {
             items.add(jsonStringArray.getString(i));
         }
@@ -67,7 +67,7 @@ public class VulnerabilityDescriptor {
         String jsonVulns = BinaryAssets.extractAsset(ctx, "vuln_map.json");
         JSONObject vulnMap = new JSONObject(jsonVulns);
 
-        Map<String, VulnerabilityDescriptor> descriptorMap = new HashMap<String, VulnerabilityDescriptor>();
+        Map<String, VulnerabilityDescriptor> descriptorMap = new HashMap<>();
         Iterator<String> keys = vulnMap.keys();
 
         while (keys.hasNext()) {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/GraphicBufferTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/GraphicBufferTest.java
@@ -44,7 +44,7 @@ public class GraphicBufferTest implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/jar/JarBug13678484.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/jar/JarBug13678484.java
@@ -19,7 +19,7 @@ public class JarBug13678484 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6602.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6602.java
@@ -23,7 +23,7 @@ public class CVE_2015_6602 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM);
         return archs;

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6608.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6608.java
@@ -114,7 +114,7 @@ public class CVE_2015_6608 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        List<CPUArch> supportedArchs = new ArrayList<CPUArch>();
+        List<CPUArch> supportedArchs = new ArrayList<>();
         supportedArchs.add(CPUArch.ARM);
         supportedArchs.add(CPUArch.ARM7);
         supportedArchs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/StageFright.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/StageFright.java
@@ -48,7 +48,7 @@ public class StageFright {
 
             File stagefrightMediaFilesFolder = new File(extractionDir);
 
-            List<VulnerabilityTest> tests = new ArrayList<VulnerabilityTest>();
+            List<VulnerabilityTest> tests = new ArrayList<>();
 
             final String extractedBinaryTester = dataDir.getAbsolutePath() + File.separator + getNativeAppName();
             extractAsset(context, "stagefright" + File.separator + getNativeAppName(),
@@ -67,7 +67,7 @@ public class StageFright {
 
                     @Override
                     public List<CPUArch> getSupportedArchitectures() {
-                        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+                        ArrayList<CPUArch> archs = new ArrayList<>();
                         archs.add(CPUArch.ARM);
                         archs.add(CPUArch.ARM7);
                         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/securerandom/SecureRandomTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/securerandom/SecureRandomTest.java
@@ -26,7 +26,7 @@ public class SecureRandomTest implements VulnerabilityTest{
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/ObjectSerializationBugTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/ObjectSerializationBugTest.java
@@ -27,7 +27,7 @@ public class ObjectSerializationBugTest implements VulnerabilityTest{
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/OpenSSLTransientBug.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/OpenSSLTransientBug.java
@@ -65,7 +65,7 @@ public class OpenSSLTransientBug implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
@@ -20,7 +20,7 @@ public class ZipBug8219321 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
@@ -32,7 +32,7 @@ public class ZipBug9695860 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }
@@ -74,8 +74,8 @@ public class ZipBug9695860 implements VulnerabilityTest {
         out.write(file2data);
         out.closeArchiveEntry();
 
-        List<ZipArchiveEntry> normalEntries = new ArrayList<ZipArchiveEntry>();
-        List<ZipArchiveEntry> moddedEntries = new ArrayList<ZipArchiveEntry>();
+        List<ZipArchiveEntry> normalEntries = new ArrayList<>();
+        List<ZipArchiveEntry> moddedEntries = new ArrayList<>();
         normalEntries.add(ze1);
         moddedEntries.add(ze2);
 

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
@@ -34,7 +34,7 @@ public class ZipBug9950697 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }
@@ -61,7 +61,7 @@ public class ZipBug9950697 implements VulnerabilityTest {
 
         zaos.flush();
 
-        List<ZipArchiveEntry> entries = new ArrayList<ZipArchiveEntry>();
+        List<ZipArchiveEntry> entries = new ArrayList<>();
         entries.add(zae);
 
         zaos.finish(entries, new ArrayList<ZipArchiveEntry>());

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2011_1149.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2011_1149.java
@@ -15,7 +15,7 @@ public class CVE_2011_1149 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         return archs;

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2013_6282.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2013_6282.java
@@ -15,7 +15,7 @@ public class CVE_2013_6282 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_3153.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_3153.java
@@ -16,7 +16,7 @@ public class CVE_2014_3153 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_4943.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_4943.java
@@ -15,7 +15,7 @@ public class CVE_2014_4943 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2015_3636.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2015_3636.java
@@ -28,7 +28,7 @@ public class CVE_2015_3636 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/CVE20153860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/CVE20153860.java
@@ -103,7 +103,7 @@ public class CVE20153860 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        final ArrayList<CPUArch> supportedArchs = new ArrayList<CPUArch>();
+        final ArrayList<CPUArch> supportedArchs = new ArrayList<>();
         supportedArchs.add(CPUArch.ALL);
         return supportedArchs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
@@ -29,7 +29,7 @@ public class SamsungCREDzip implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/StumpRoot.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/StumpRoot.java
@@ -66,7 +66,7 @@ public class StumpRoot implements VulnerabilityTest  {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/WeakSauce.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/WeakSauce.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class WeakSauce implements VulnerabilityTest {
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/ZergRush.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/ZergRush.java
@@ -20,7 +20,7 @@ public class ZergRush implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/org/apache/commons/compress/archivers/zip/ModdedZipArchiveOutputStream.java
+++ b/app/src/main/java/org/apache/commons/compress/archivers/zip/ModdedZipArchiveOutputStream.java
@@ -140,7 +140,7 @@ public class ModdedZipArchiveOutputStream extends ArchiveOutputStream {
      * List of ZipArchiveEntries written so far.
      */
     protected final List<ZipArchiveEntry> entries =
-            new LinkedList<ZipArchiveEntry>();
+            new LinkedList<>();
 
     /**
      * CRC instance to avoid parsing DEFLATED data twice.
@@ -176,7 +176,7 @@ public class ModdedZipArchiveOutputStream extends ArchiveOutputStream {
      * Holds the offsets of the LFH starts for each entry.
      */
     protected final Map<ZipArchiveEntry, Long> offsets =
-            new HashMap<ZipArchiveEntry, Long>();
+            new HashMap<>();
 
     /**
      * The encoding to use for filenames and the file comment.
@@ -442,7 +442,7 @@ public class ModdedZipArchiveOutputStream extends ArchiveOutputStream {
             dummyFile.setRawCentralDirectoryExtra(centralHeaderBytes.toByteArray());
 
             int normalEntriesNeeded = hiddenEntries.size() - normalEntries.size();
-            List<ZipArchiveEntry> gennedEntries = new ArrayList<ZipArchiveEntry>();
+            List<ZipArchiveEntry> gennedEntries = new ArrayList<>();
             for(int i = 0; i < normalEntriesNeeded; i++){
                 ZipArchiveEntry generatedZipEntry = generateRandomDummyZipEntry();
                 putArchiveEntry(generatedZipEntry);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.