### PR TITLE
The operator ("<>") should be used.

### DIFF
--- a/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertFactoryImpl.java
+++ b/app/src/main/java/android/framework/org/apache/harmony/security_custom/provider/cert/X509CertFactoryImpl.java
@@ -123,7 +123,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
         if (inStream == null) {
             throw new CertificateException("inStream == null");
         }
-        ArrayList<Certificate> result = new ArrayList<Certificate>();
+        ArrayList<Certificate> result = new ArrayList<>();
         try {
             if (!inStream.markSupported()) {
                 // create the mark supporting wrapper
@@ -264,7 +264,7 @@ public class X509CertFactoryImpl extends CertificateFactorySpi {
         if (inStream == null) {
             throw new CRLException("inStream == null");
         }
-        ArrayList<CRL> result = new ArrayList<CRL>();
+        ArrayList<CRL> result = new ArrayList<>();
         try {
             if (!inStream.markSupported()) {
                 inStream = new RestoringInputStream(inStream);

--- a/app/src/main/java/android/framework/util/jar/JarFileHelper.java
+++ b/app/src/main/java/android/framework/util/jar/JarFileHelper.java
@@ -40,13 +40,13 @@ public class JarFileHelper {
 
 
     public static boolean isExploitingBug13678484(String apkName) throws Exception {
-        ArrayList<String> validatedCertChain = new ArrayList<String>();
+        ArrayList<String> validatedCertChain = new ArrayList<>();
 
         Certificate[] certs = JarFileHelper.getSignedJarCerts(apkName, true);
         for(Certificate c: certs)
             validatedCertChain.add(((X509Certificate)c).getSubjectDN().toString());
 
-        ArrayList<String> unvalidatedCertChain = new ArrayList<String>();
+        ArrayList<String> unvalidatedCertChain = new ArrayList<>();
 
         Certificate[] certsfalse = JarFileHelper.getSignedJarCerts(apkName, false);
         for(Certificate c: certsfalse)

--- a/app/src/main/java/fr/xgouchet/axml/CompressedXmlDomListener.java
+++ b/app/src/main/java/fr/xgouchet/axml/CompressedXmlDomListener.java
@@ -39,7 +39,7 @@ public class CompressedXmlDomListener implements CompressedXmlParserListener {
 	 */
 	public CompressedXmlDomListener() throws ParserConfigurationException {
 		mBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-		mStack = new Stack<Node>();
+		mStack = new Stack<>();
 	}
 
 	public void startDocument() {

--- a/app/src/main/java/fr/xgouchet/axml/CompressedXmlParser.java
+++ b/app/src/main/java/fr/xgouchet/axml/CompressedXmlParser.java
@@ -65,7 +65,7 @@ public class CompressedXmlParser {
 			"pt", "in", "mm" };
 
 	public CompressedXmlParser() {
-		mNamespaces = new HashMap<String, String>();
+		mNamespaces = new HashMap<>();
 	}
 
 	/**

--- a/app/src/main/java/fuzion24/application/vulnerability/detector/ApplicationVulnerabilityTester.java
+++ b/app/src/main/java/fuzion24/application/vulnerability/detector/ApplicationVulnerabilityTester.java
@@ -46,8 +46,8 @@ public class ApplicationVulnerabilityTester extends AsyncTask<Void,Integer,List<
             PackageManager pm = mCtx.getPackageManager();
             List<ApplicationInfo> apps = pm.getInstalledApplications(PackageManager.GET_SHARED_LIBRARY_FILES | PackageManager.GET_META_DATA);
 
-            List<ApplicationVulnTestResult> applicationVulnerabilityTestResults = new ArrayList<ApplicationVulnTestResult>();
-            List<Pair<ApplicationInfo,Exception>> untestedApps = new ArrayList<Pair<ApplicationInfo,Exception>>();
+            List<ApplicationVulnTestResult> applicationVulnerabilityTestResults = new ArrayList<>();
+            List<Pair<ApplicationInfo,Exception>> untestedApps = new ArrayList<>();
 
             for(int i = 0; i < apps.size(); i++) {
 

--- a/app/src/main/java/fuzion24/device/vulnerability/broadcastreceiver/ScanRunnerBroadcastReceiver.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/broadcastreceiver/ScanRunnerBroadcastReceiver.java
@@ -61,7 +61,7 @@ public class ScanRunnerBroadcastReceiver extends BroadcastReceiver {
             @Override
             protected Void doInBackground(Void... params) {
                 List<VulnerabilityTest> tests = VulnerabilityOrganizer.getTests(context);
-                List<VulnerabilityTestResult> results = new ArrayList<VulnerabilityTestResult>();
+                List<VulnerabilityTestResult> results = new ArrayList<>();
                 for(VulnerabilityTest vt : tests){
                     Log.d(TAG, "Running: " + vt.getCVEorID());
                     boolean vulnerable = false;

--- a/app/src/main/java/fuzion24/device/vulnerability/test/VulnerabilityDescriptor.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/test/VulnerabilityDescriptor.java
@@ -55,7 +55,7 @@ public class VulnerabilityDescriptor {
 
     private static List<String> extractStringArray(JSONObject obj, String arrayName) throws Exception {
         JSONArray jsonStringArray = obj.getJSONArray(arrayName);
-        List<String> items = new ArrayList<String>();
+        List<String> items = new ArrayList<>();
         for (int i = 0; i < jsonStringArray.length(); i++) {
             items.add(jsonStringArray.getString(i));
         }
@@ -67,7 +67,7 @@ public class VulnerabilityDescriptor {
         String jsonVulns = BinaryAssets.extractAsset(ctx, "vuln_map.json");
         JSONObject vulnMap = new JSONObject(jsonVulns);
 
-        Map<String, VulnerabilityDescriptor> descriptorMap = new HashMap<String, VulnerabilityDescriptor>();
+        Map<String, VulnerabilityDescriptor> descriptorMap = new HashMap<>();
         Iterator<String> keys = vulnMap.keys();
 
         while (keys.hasNext()) {

--- a/app/src/main/java/fuzion24/device/vulnerability/update/client/RetrofitClient.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/update/client/RetrofitClient.java
@@ -1,8 +1,8 @@
 package fuzion24.device.vulnerability.update.client;
 
-import retrofit2.GsonConverterFactory;
+//import retrofit2.GsonConverterFactory;
 import retrofit2.Retrofit;
-import retrofit2.RxJavaCallAdapterFactory;
+//import retrofit2.RxJavaCallAdapterFactory;
 
 /**
  * Retrofit client.
@@ -11,11 +11,12 @@ import retrofit2.RxJavaCallAdapterFactory;
 public class RetrofitClient {
 
     public static Retrofit getRetrofitClient() {
-        return new Retrofit.Builder()
-            .baseUrl("https://api.github.com/")
-            .addConverterFactory(GsonConverterFactory.create())
-            .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-            .build();
+//        return new Retrofit.Builder()
+//            .baseUrl("https://api.github.com/")
+//            .addConverterFactory(GsonConverterFactory.create())
+//            .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+//            .build();
+        return null;
     }
 
 }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/GraphicBufferTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/GraphicBufferTest.java
@@ -44,7 +44,7 @@ public class GraphicBufferTest implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/jar/JarBug13678484.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/jar/JarBug13678484.java
@@ -19,7 +19,7 @@ public class JarBug13678484 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6602.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6602.java
@@ -23,7 +23,7 @@ public class CVE_2015_6602 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM);
         return archs;

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6608.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6608.java
@@ -114,7 +114,7 @@ public class CVE_2015_6608 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        List<CPUArch> supportedArchs = new ArrayList<CPUArch>();
+        List<CPUArch> supportedArchs = new ArrayList<>();
         supportedArchs.add(CPUArch.ARM);
         supportedArchs.add(CPUArch.ARM7);
         supportedArchs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/StageFright.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/StageFright.java
@@ -48,7 +48,7 @@ public class StageFright {
 
             File stagefrightMediaFilesFolder = new File(extractionDir);
 
-            List<VulnerabilityTest> tests = new ArrayList<VulnerabilityTest>();
+            List<VulnerabilityTest> tests = new ArrayList<>();
 
             final String extractedBinaryTester = dataDir.getAbsolutePath() + File.separator + getNativeAppName();
             extractAsset(context, "stagefright" + File.separator + getNativeAppName(),
@@ -67,7 +67,7 @@ public class StageFright {
 
                     @Override
                     public List<CPUArch> getSupportedArchitectures() {
-                        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+                        ArrayList<CPUArch> archs = new ArrayList<>();
                         archs.add(CPUArch.ARM);
                         archs.add(CPUArch.ARM7);
                         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/securerandom/SecureRandomTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/securerandom/SecureRandomTest.java
@@ -26,7 +26,7 @@ public class SecureRandomTest implements VulnerabilityTest{
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/ObjectSerializationBugTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/ObjectSerializationBugTest.java
@@ -27,7 +27,7 @@ public class ObjectSerializationBugTest implements VulnerabilityTest{
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
@@ -20,7 +20,7 @@ public class ZipBug8219321 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
@@ -32,7 +32,7 @@ public class ZipBug9695860 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }
@@ -74,8 +74,8 @@ public class ZipBug9695860 implements VulnerabilityTest {
         out.write(file2data);
         out.closeArchiveEntry();
 
-        List<ZipArchiveEntry> normalEntries = new ArrayList<ZipArchiveEntry>();
-        List<ZipArchiveEntry> moddedEntries = new ArrayList<ZipArchiveEntry>();
+        List<ZipArchiveEntry> normalEntries = new ArrayList<>();
+        List<ZipArchiveEntry> moddedEntries = new ArrayList<>();
         normalEntries.add(ze1);
         moddedEntries.add(ze2);
 

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
@@ -34,7 +34,7 @@ public class ZipBug9950697 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }
@@ -61,7 +61,7 @@ public class ZipBug9950697 implements VulnerabilityTest {
 
         zaos.flush();
 
-        List<ZipArchiveEntry> entries = new ArrayList<ZipArchiveEntry>();
+        List<ZipArchiveEntry> entries = new ArrayList<>();
         entries.add(zae);
 
         zaos.finish(entries, new ArrayList<ZipArchiveEntry>());

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2011_1149.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2011_1149.java
@@ -15,7 +15,7 @@ public class CVE_2011_1149 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         return archs;

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2013_6282.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2013_6282.java
@@ -15,7 +15,7 @@ public class CVE_2013_6282 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_3153.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_3153.java
@@ -16,7 +16,7 @@ public class CVE_2014_3153 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_4943.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_4943.java
@@ -15,7 +15,7 @@ public class CVE_2014_4943 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2015_3636.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2015_3636.java
@@ -28,7 +28,7 @@ public class CVE_2015_3636 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ARM);
         archs.add(CPUArch.ARM7);
         archs.add(CPUArch.ARM8);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/CVE20153860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/CVE20153860.java
@@ -103,7 +103,7 @@ public class CVE20153860 implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        final ArrayList<CPUArch> supportedArchs = new ArrayList<CPUArch>();
+        final ArrayList<CPUArch> supportedArchs = new ArrayList<>();
         supportedArchs.add(CPUArch.ALL);
         return supportedArchs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
@@ -29,7 +29,7 @@ public class SamsungCREDzip implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/StumpRoot.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/StumpRoot.java
@@ -66,7 +66,7 @@ public class StumpRoot implements VulnerabilityTest  {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/WeakSauce.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/WeakSauce.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class WeakSauce implements VulnerabilityTest {
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/ZergRush.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/ZergRush.java
@@ -20,7 +20,7 @@ public class ZergRush implements VulnerabilityTest {
 
     @Override
     public List<CPUArch> getSupportedArchitectures() {
-        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        ArrayList<CPUArch> archs = new ArrayList<>();
         archs.add(CPUArch.ALL);
         return archs;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.