### PR TITLE
fix detection of CVE-2015-6616 patches

### DIFF
--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6616.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6616.java
@@ -1,6 +1,7 @@
 package fuzion24.device.vulnerability.vulnerabilities.framework.media;
 
 import android.content.Context;
+import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -27,12 +28,14 @@ public class CVE_2015_6616  implements VulnerabilityTest {
     ANDROID-24441553	Critical	6.0 and below	Sep 22, 2015
     ANDROID-24157524	Critical	6.0	Sep 08, 2015
 
-    ANDROID-24630158 https://android.googlesource.com/platform%2Fframeworks%2Fav/+/77c185d5499d6174e7a97b3e1512994d3a803151
+    ANDROID-24630158 https://android.googlesource.com/platform%2Fframeworks%2Fav/+/257b3bc581bbc65318a4cc2d3c22a07a4429dc1d
     ANDROID-23882800 https://android.googlesource.com/platform%2Fframeworks%2Fav/+/0d35dd2068d6422c3c77fb68f248cbabf3d0b10c
     ANDROID-17769851 https://android.googlesource.com/platform%2Fframeworks%2Fav/+/dedaca6f04ac9f95fabe3b64d44cd1a2050f079e
     ANDROID-24441553 https://android.googlesource.com/platform%2Fframeworks%2Fav/+/5d101298d8b0a78a1dc5bd26dbdada411f4ecd4d
     ANDROID-24157524 https://android.googlesource.com/platform%2Fexternal%2Flibavc/+/2ee0c1bced131ffb06d1b430b08a202cd3a52005
 */
+
+    private static final String TAG = "CVE-2015-6616";
 
     @Override
     public String getCVEorID() {
@@ -46,23 +49,37 @@ public class CVE_2015_6616  implements VulnerabilityTest {
             throw new Exception("libstagefright.so doesn't exist or is not a file");
         }
 
+        File stagefrightsoftmp4lib = new File("/system/lib/libstagefright_soft_mpeg4dec.so");
+        if(!stagefrightsoftmp4lib.exists() || !stagefrightsoftmp4lib.isFile()){
+            throw new Exception("libstagefright_soft_mpeg4dec.so doesn't exist or is not a file");
+        }
+
+
         ByteArrayOutputStream libStageFrightBAOS = new ByteArrayOutputStream((int)stagefrightlib.length());
         BinaryAssets.copy(new FileInputStream(stagefrightlib), libStageFrightBAOS);
         byte[] libstagefrightSO = libStageFrightBAOS.toByteArray();
 
         KMPMatch binMatcher = new KMPMatch();
 
-        int indexOf = binMatcher.indexOf(libstagefrightSO, "b/24445127".getBytes());
-        boolean libstagefrightVulnerableToBug24445127 = indexOf == -1;
-
-        indexOf = binMatcher.indexOf(libstagefrightSO, "bogus max input size: %zu".getBytes());
+        int indexOf = binMatcher.indexOf(libstagefrightSO, "bogus max input size: %zu".getBytes());
         boolean libstagefrightVulnerableToBug17769851 = indexOf == -1;
 
         indexOf = binMatcher.indexOf(libstagefrightSO, "b/24441553, b/24445122".getBytes());
         boolean libstagefrightVulnerableToBug24441553 = indexOf == -1;
 
+        ByteArrayOutputStream libStageFrightsoftmp4BAOS = new ByteArrayOutputStream((int)stagefrightsoftmp4lib.length());
+        BinaryAssets.copy(new FileInputStream(stagefrightsoftmp4lib), libStageFrightsoftmp4BAOS);
+        byte[] libstagefrightsoftmp4SO = libStageFrightsoftmp4BAOS.toByteArray();
 
-        return libstagefrightVulnerableToBug24445127 ||
+        indexOf = binMatcher.indexOf(libstagefrightsoftmp4SO, "b/24630158".getBytes());
+        boolean libstagefrightVulnerableToBug24630158 = indexOf == -1;
+
+        Log.d(TAG, "libstagefrightVulnerableToBug24630158: " + libstagefrightVulnerableToBug24630158);
+        Log.d(TAG, "libstagefrightVulnerableToBug17769851: " + libstagefrightVulnerableToBug17769851);
+        Log.d(TAG, "libstagefrightVulnerableToBug24441553: " + libstagefrightVulnerableToBug24441553);
+
+
+        return libstagefrightVulnerableToBug24630158 ||
                 libstagefrightVulnerableToBug17769851 ||
                 libstagefrightVulnerableToBug24441553;
     }


### PR DESCRIPTION
There seemed to be one wrong bug number in CVE_2015_6616.java.

Instead of bug 24630158 (of CVE-2015-6616), bug 24445127 (from CVE-2015-6620)
was checked. The list of bugs in the comments had a wrong URL for bug 24630158 too.

The detection of 24630158 is done in libstagefright_soft_mpeg4dec.so,
the other 2 bugs that were part of this check are still
detected in libstagefright.so