### PR TITLE
Add cve 2016 0808

### DIFF
--- a/app/src/main/assets/vuln_map.json
+++ b/app/src/main/assets/vuln_map.json
@@ -1,4 +1,18 @@
 {
+  "CVE-2016-0808": {
+    "cve": "CVE-2016-0808",
+    "altnames": [],
+    "description": "This vulnerability is what is known as a denial-of-service which gives a malicious application or individual the ability to cause continuous rebooting",
+    "impact": "Continuous reboot",
+    "external_links": [
+      "https://android.googlesource.com/platform/frameworks/minikin/+/ed4c8d79153baab7f26562afb8930652dfbf853b"
+    ],
+    "patch": [
+      "https://android.googlesource.com/platform/frameworks/minikin/+/ed4c8d79153baab7f26562afb8930652dfbf853b%5E%21/#F0"
+    ],
+    "cvssv2": 4.9,
+    "cvedate": "02/01/2016"
+  },
   "CVE-2015-3636": {
     "cve": "CVE-2015-3636",
     "altnames": [

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityOrganizer.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityOrganizer.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import fuzion24.device.vulnerability.util.CPUArch;
+import fuzion24.device.vulnerability.vulnerabilities.framework.graphics.CVE_2016_0808;
 import fuzion24.device.vulnerability.vulnerabilities.framework.graphics.GraphicBufferTest;
 import fuzion24.device.vulnerability.vulnerabilities.framework.media.CVE_2015_6602;
 import fuzion24.device.vulnerability.vulnerabilities.framework.media.CVE_2015_6608;
@@ -38,7 +39,10 @@ public class VulnerabilityOrganizer {
 
     //TODO: Maybe add dates to each of these and sort chronologically
     public static List<VulnerabilityTest> getTests(Context ctx){
+
         List<VulnerabilityTest> allTests = new ArrayList<>();
+
+        allTests.add(new CVE_2016_0808());
         allTests.add(new ZipBug9950697());
         allTests.add(new ZipBug8219321());
         allTests.add(new ZipBug9695860());

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/CVE_2016_0808.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/CVE_2016_0808.java
@@ -40,16 +40,6 @@ public class CVE_2016_0808 implements VulnerabilityTest{
         Log.e( getCVEorID(), "cpu stuffs: " + DeviceInfo.getDeviceInfo().getBuildCpuABI() );
 
         return IsVuln( cpuArch1 ) || IsVuln( cpuArch2 );
-
-
-        /*int checkVal = 0;//checkCVE20160808();
-        if(checkVal == 0) {
-            return false;
-        }else if(checkVal == 1) {
-            return true;
-        }else {
-            throw new Exception("Error running test");
-        }*/
     }
 
     private boolean IsVuln( String arch )

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/CVE_2016_0808.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/CVE_2016_0808.java
@@ -37,8 +37,6 @@ public class CVE_2016_0808 implements VulnerabilityTest{
             cpuArch2 = "";
         }
 
-        Log.e( getCVEorID(), "cpu stuffs: " + DeviceInfo.getDeviceInfo().getBuildCpuABI() );
-
         return IsVuln( cpuArch1 ) || IsVuln( cpuArch2 );
     }
 

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/CVE_2016_0808.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/CVE_2016_0808.java
@@ -1,0 +1,122 @@
+package fuzion24.device.vulnerability.vulnerabilities.framework.graphics;
+
+import android.content.Context;
+import android.util.Log;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
+import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
+import fuzion24.device.vulnerability.util.DeviceInfo;
+import fuzion24.device.vulnerability.vulnerabilities.helper.BinaryAssets;
+import fuzion24.device.vulnerability.vulnerabilities.helper.KMPMatch;
+import fuzion24.device.vulnerability.vulnerabilities.helper.SystemUtils;
+
+/**
+ * Created by kg on 09/03/16.
+ */
+public class CVE_2016_0808 implements VulnerabilityTest{
+
+    @Override
+    public String getCVEorID() {
+        return "CVE-2016-0808";
+    }
+
+    @Override
+    public boolean isVulnerable(Context context) throws Exception {
+
+        String cpuArch1 = SystemUtils.propertyGet( context, "ro.product.cpu.abi" );
+        String cpuArch2 = SystemUtils.propertyGet( context, "ro.product.cpu.abi2" );
+        if( cpuArch1 == cpuArch2 )
+        {
+            cpuArch2 = "";
+        }
+
+        Log.e( getCVEorID(), "cpu stuffs: " + DeviceInfo.getDeviceInfo().getBuildCpuABI() );
+
+        return IsVuln( cpuArch1 ) || IsVuln( cpuArch2 );
+
+
+        /*int checkVal = 0;//checkCVE20160808();
+        if(checkVal == 0) {
+            return false;
+        }else if(checkVal == 1) {
+            return true;
+        }else {
+            throw new Exception("Error running test");
+        }*/
+    }
+
+    private boolean IsVuln( String arch )
+    {
+        // this method doesn't work for arm64.  the 0x15555553 is not stored in a literal pool
+        // MOV             W26, #0x5553
+        // MOVK            W26, #0x1555,LSL#16
+        // CMP             W0, W26
+
+
+        // 32bit arm
+        String thePath;
+        byte[] theBytes;
+        if( CPUArch.ARM7.getArch().equals( arch )
+                || CPUArch.ARM.getArch().equals( arch ) )
+        {
+            thePath = "/system/lib/libminikin.so";
+            theBytes = new byte[] {0x53, 0x55, 0x55, 0x15};
+        }
+        else
+        {
+            if( !arch.isEmpty() )
+            {
+                Log.e( getCVEorID(), "unsupported arch: " + arch );
+            }
+            return false;
+        }
+        File theFile = new File(thePath);
+
+        if(!theFile.exists() || !theFile.isFile()){
+            Log.e( getCVEorID(), "vulnerable for arch: " + arch );
+            return false;
+        }
+
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream((int)theFile.length());
+        try
+        {
+            BinaryAssets.copy(new FileInputStream(theFile), baos);
+        }
+        catch(Exception e)
+        {
+            Log.e( getCVEorID(), "error reading file: " + thePath );
+            e.printStackTrace();
+            return false;
+        }
+        byte[] so = baos.toByteArray();
+
+
+        KMPMatch binMatcher = new KMPMatch();
+
+
+        int indexOf = binMatcher.indexOf(so, theBytes);
+        if( indexOf == -1 )
+        {
+            Log.e( getCVEorID(), "vulnerable for arch: " + arch );
+            return true;
+        }
+        Log.e( getCVEorID(), "pattern not found in the file: " + thePath );
+        return false;
+    }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        archs.add(CPUArch.ARM);
+        return archs;
+    }
+}


### PR DESCRIPTION
based off https://github.com/AndroidVTS/android-vts/pull/134
 - not adding in details for vulns from 2009 that were fixed in gingerbread.  This app won't install or run on those phones.  minimum SDK is 15 (Android 4.0.3)
 - use java and KMPMatch to perform the search rather than adding a native library for each supported architecture